### PR TITLE
:wrench: Add `libc` setting to baremetal/v2

### DIFF
--- a/profiles/baremetal/v2/settings_user.yml
+++ b/profiles/baremetal/v2/settings_user.yml
@@ -17,3 +17,5 @@ arch:
     "cortex-m55",
     "cortex-m85",
   ]
+
+libc: [null, "default", "custom"]


### PR DESCRIPTION
The `libc` setting is used by compilers to provide information about whether or not a custom libc should be used or if the default should be used. This is most helpful for test packages and building applications, where test packages need to use the defaults to link properly and applications will want to choose their libc version.