### PR TITLE
:bug: Remove libc++ from clang in windows profiles

### DIFF
--- a/profiles/armv8/windows/default
+++ b/profiles/armv8/windows/default
@@ -3,7 +3,6 @@ arch=armv8
 build_type=Release
 compiler=clang
 compiler.cppstd=23
-compiler.libcxx=libc++
 compiler.version=17
 os=Windows
 

--- a/profiles/x86_64/windows/default
+++ b/profiles/x86_64/windows/default
@@ -3,7 +3,6 @@ arch=x86_64
 build_type=Release
 compiler=clang
 compiler.cppstd=23
-compiler.libcxx=libc++
 compiler.version=17
 os=Windows
 


### PR DESCRIPTION
This "may" be the cause of the issues we have with windows building. It needs MSVC STL.